### PR TITLE
Add command prompt support

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,0 +1,3 @@
+[
+    { "command": "toggle_readonly", "caption": "Toggle Readonly" }
+]


### PR DESCRIPTION
Hi,

First, thank you for your plugin.

Here is a small patch for a command prompt support. I find that using the mouse for toggling read-only mode on and off can be very disruptive to my workflow.

Thanks.

Regards,
Tony
